### PR TITLE
Fix DDE tab updates in GUI

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -275,10 +275,12 @@ class AppController:
                     self.trade_history.refresh_data()
             elif tab_index == 2 and self.system_status:
                 self.system_status.update_data(self.system_status_data, self.connection_status)
-            elif tab_index == 3 and self.economic_calendar:
+            elif tab_index == 3 and hasattr(self.dde_price_feed, 'refresh_data'):
+                self.dde_price_feed.refresh_data()
+            elif tab_index == 4 and self.economic_calendar:
                 # Economic calendar doesn't need frequent updates
                 pass
-            elif tab_index == 4 and self.settings_panel:
+            elif tab_index == 5 and self.settings_panel:
                 # Settings panel doesn't need frequent updates
                 pass
                 


### PR DESCRIPTION
## Summary
- refresh DDE price feed tab during active tab updates
- correct tab index handling for economic calendar and settings tabs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'signals'; win32ui; numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b8afba5ac4832f8067f8f0b01cb092