### PR TITLE
Add Friday volatility signal module and tests

### DIFF
--- a/tests/test_friday_vol_signal.py
+++ b/tests/test_friday_vol_signal.py
@@ -1,6 +1,12 @@
 
 # tests/test_friday_vol_signal.py
 from datetime import datetime
+import pathlib
+import sys
+
+# Allow running tests without installing the package
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
 from signals.friday_vol_signal import FridayVolSignal, FridayVolSignalConfig, UTC
 
 # Freeze to a known Friday after 14:00 Chicago: 2025-08-29 20:10:00 UTC


### PR DESCRIPTION
## Summary
- Add FridayVolSignal implementation using standard library zoneinfo
- Include supporting test covering trigger and threshold logic

## Testing
- `pytest tests/test_friday_vol_signal.py`
- `pytest` *(fails: No module named 'win32ui'; No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b8af673e18832fb0409bfc82eba1c6