### PR TITLE
feat: add matrix parameter configuration tab

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -22,6 +22,7 @@ from tabs.system_status import SystemStatusTab
 from tabs.settings_panel import SettingsPanel
 from tabs.economic_calendar import EconomicCalendar
 from tabs.dde_price_feed import create_dde_tab
+from tabs.matrix_parameters import MatrixParametersTab
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class AppController:
         self.system_status = None
         self.settings_panel = None
         self.economic_calendar = None
+        self.matrix_parameters = None
         
         # Data containers
         self.system_status_data = SystemStatusData()
@@ -171,8 +173,12 @@ class AppController:
         # Tab 5: Economic Calendar
         self.economic_calendar = EconomicCalendar(self.notebook, self)
         self.notebook.add(self.economic_calendar.frame, text="📅 Economic Calendar")
-        
-        # Tab 6: Settings
+
+        # Tab 6: Matrix Parameters
+        self.matrix_parameters = MatrixParametersTab(self.notebook, self)
+        self.notebook.add(self.matrix_parameters.frame, text="🧮 Matrix Parameters")
+
+        # Tab 7: Settings
         self.settings_panel = SettingsPanel(self.notebook, self)
         self.notebook.add(self.settings_panel.frame, text="⚙️ Settings")
         

--- a/tabs/__init__.py
+++ b/tabs/__init__.py
@@ -7,10 +7,12 @@ from .live_dashboard import LiveDashboard
 from .trade_history import TradeHistory
 from .system_status import SystemStatus as SystemStatusTab
 from .settings_panel import SettingsPanel
+from .matrix_parameters import MatrixParametersTab
 
 __all__ = [
     'LiveDashboard',
-    'TradeHistory', 
+    'TradeHistory',
     'SystemStatusTab',
-    'SettingsPanel'
+    'SettingsPanel',
+    'MatrixParametersTab'
 ]

--- a/tabs/matrix_parameters.py
+++ b/tabs/matrix_parameters.py
@@ -1,0 +1,138 @@
+"""
+HUEY_P Trading Interface - Matrix Parameters Tab
+Configure matrix parameter sets used by the trading system
+"""
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+class MatrixParametersTab:
+    """UI tab for managing matrix parameter sets"""
+
+    def __init__(self, parent, app_controller):
+        self.parent = parent
+        self.app_controller = app_controller
+        self.frame = None
+
+        # Simple in-memory storage for demonstration purposes
+        self.parameter_sets: Dict[str, str] = {}
+
+        # Editor variables
+        self.name_var = tk.StringVar()
+        self.value_var = tk.StringVar()
+
+        self.setup_ui()
+
+    def setup_ui(self):
+        """Build the tab UI"""
+        # Main frame
+        self.frame = ttk.Frame(self.parent)
+
+        # Create layout containers
+        main_container = ttk.Frame(self.frame)
+        main_container.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        # Left panel - list of parameter sets
+        self.list_frame = ttk.LabelFrame(main_container, text="📚 Parameter Sets", padding=10)
+        self.list_frame.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 5))
+
+        self.setup_parameter_list()
+
+        # Right panel - editor
+        self.editor_frame = ttk.LabelFrame(main_container, text="✏️ Edit Parameter Set", padding=10)
+        self.editor_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(5, 0))
+
+        self.setup_editor()
+        self.setup_controls()
+
+        logger.info("Matrix parameters tab UI setup complete")
+
+    def setup_parameter_list(self):
+        """Setup list of existing parameter sets"""
+        list_container = ttk.Frame(self.list_frame)
+        list_container.pack(fill=tk.BOTH, expand=True)
+
+        self.listbox = tk.Listbox(list_container, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        scrollbar = ttk.Scrollbar(list_container, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.configure(yscrollcommand=scrollbar.set)
+
+        self.listbox.bind("<<ListboxSelect>>", self.on_set_selected)
+
+    def setup_editor(self):
+        """Setup editor fields"""
+        self.editor_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(self.editor_frame, text="Name:").grid(row=0, column=0, sticky=tk.W, pady=2)
+        ttk.Entry(self.editor_frame, textvariable=self.name_var).grid(row=0, column=1, sticky=tk.EW, pady=2)
+
+        ttk.Label(self.editor_frame, text="Value:").grid(row=1, column=0, sticky=tk.W, pady=2)
+        ttk.Entry(self.editor_frame, textvariable=self.value_var).grid(row=1, column=1, sticky=tk.EW, pady=2)
+
+    def setup_controls(self):
+        """Setup control buttons"""
+        btn_frame = ttk.Frame(self.editor_frame)
+        btn_frame.grid(row=2, column=0, columnspan=2, pady=(10, 0))
+
+        ttk.Button(btn_frame, text="New", command=self.new_parameter_set).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Save", command=self.save_parameter_set).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Delete", command=self.delete_parameter_set).pack(side=tk.LEFT, padx=5)
+
+    def new_parameter_set(self):
+        """Clear editor for new parameter set"""
+        self.name_var.set("")
+        self.value_var.set("")
+        self.listbox.selection_clear(0, tk.END)
+
+    def save_parameter_set(self):
+        """Save or update a parameter set"""
+        name = self.name_var.get().strip()
+        value = self.value_var.get().strip()
+
+        if not name:
+            messagebox.showerror("Validation Error", "Name is required")
+            return
+
+        self.parameter_sets[name] = value
+
+        # Update listbox
+        current_items = list(self.listbox.get(0, tk.END))
+        if name not in current_items:
+            self.listbox.insert(tk.END, name)
+        else:
+            idx = current_items.index(name)
+            self.listbox.delete(idx)
+            self.listbox.insert(idx, name)
+            self.listbox.selection_set(idx)
+
+        logger.info("Saved parameter set '%s'", name)
+
+    def delete_parameter_set(self):
+        """Delete selected parameter set"""
+        selection = self.listbox.curselection()
+        if not selection:
+            return
+        idx = selection[0]
+        name = self.listbox.get(idx)
+        if messagebox.askyesno("Delete", f"Delete parameter set '{name}'?"):
+            self.listbox.delete(idx)
+            self.parameter_sets.pop(name, None)
+            self.new_parameter_set()
+            logger.info("Deleted parameter set '%s'", name)
+
+    def on_set_selected(self, event):
+        """Load selected parameter set into editor"""
+        selection = self.listbox.curselection()
+        if not selection:
+            return
+        idx = selection[0]
+        name = self.listbox.get(idx)
+        self.name_var.set(name)
+        self.value_var.set(self.parameter_sets.get(name, ""))


### PR DESCRIPTION
## Summary
- expose new Matrix Parameters tab and register it with the main controller
- implement MatrixParametersTab with basic list and editor for parameter sets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'win32ui', No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pip install pywin32` *(fails: Could not find a version that satisfies the requirement pywin32)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c0e83404832fa5be6139fa9b7923