### PR TITLE
Add placeholder trading-system tools and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# eafix Trading System Tools
+
+This repository contains placeholder trading-system utilities and a basic economic
+calendar processing scaffold. The tools in `tools/` emit deterministic outputs,
+allowing early-stage pipelines to be wired without depending on real trading
+infrastructure.
+
+Run the test suite with:
+
+```bash
+pytest -q
+```

--- a/calendar_processing.py
+++ b/calendar_processing.py
@@ -1,0 +1,59 @@
+"""Calendar CSV processing helpers."""
+from __future__ import annotations
+import csv
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import List
+
+
+@dataclass
+class Event:
+    time: datetime
+    currency: str
+    impact: str
+    event: str
+    anticipation: bool = False
+
+
+def read_csv_calendar(path: str) -> List[Event]:
+    """Read events from a CSV file with columns: time,currency,impact,event."""
+    events: List[Event] = []
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            events.append(
+                Event(
+                    time=datetime.fromisoformat(row["time"]),
+                    currency=row["currency"],
+                    impact=row["impact"],
+                    event=row["event"],
+                )
+            )
+    return events
+
+
+def filter_events(events: List[Event], impacts=("High", "Medium"), exclude_currency="CHF") -> List[Event]:
+    """Filter events by impact and exclude a currency."""
+    return [e for e in events if e.impact in impacts and e.currency != exclude_currency]
+
+
+def generate_all_anticipation_events(events: List[Event], hours=(1, 2, 4, 8, 12)) -> List[Event]:
+    """Create anticipation events offset by specified hours before the event."""
+    anticipations: List[Event] = []
+    for event in events:
+        for h in hours:
+            anticipations.append(
+                Event(
+                    time=event.time - timedelta(hours=h),
+                    currency=event.currency,
+                    impact=event.impact,
+                    event=event.event,
+                    anticipation=True,
+                )
+            )
+    return anticipations
+
+
+def sort_events_chronologically(events: List[Event]) -> List[Event]:
+    """Return events sorted by time."""
+    return sorted(events, key=lambda e: e.time)

--- a/signals_output.py
+++ b/signals_output.py
@@ -1,0 +1,14 @@
+"""Trading signal output helpers."""
+from __future__ import annotations
+import csv
+from typing import Iterable
+from calendar_processing import Event
+
+
+def write_signals(events: Iterable[Event], path: str) -> None:
+    """Write events to CSV in a simplified signal format."""
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["time", "currency", "impact", "event", "anticipation"])
+        for e in events:
+            writer.writerow([e.time.isoformat(), e.currency, e.impact, e.event, int(e.anticipation)])

--- a/strategy_id.py
+++ b/strategy_id.py
@@ -1,0 +1,17 @@
+"""Strategy ID generation utilities."""
+from __future__ import annotations
+import hashlib
+
+
+def generate(country: str, impact: str, anticipation: bool = False) -> int:
+    """Generate a simple numeric strategy identifier.
+
+    The ID is derived from the country and impact strings with a checksum.
+    Anticipation events receive an additional offset of 1000.
+    """
+    base = (country + impact).upper()
+    checksum = int(hashlib.sha1(base.encode()).hexdigest(), 16) % 1000
+    sid = checksum
+    if anticipation:
+        sid += 1000
+    return sid

--- a/tests/data/sample_calendar.csv
+++ b/tests/data/sample_calendar.csv
@@ -1,0 +1,4 @@
+time,currency,impact,event
+2025-01-01T10:00:00,USD,High,Nonfarm Payrolls
+2025-01-02T12:00:00,CHF,High,Swiss Event
+2025-01-03T09:00:00,EUR,Medium,ECB Meeting

--- a/tests/test_calendar_processing.py
+++ b/tests/test_calendar_processing.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from calendar_processing import (
+    read_csv_calendar,
+    filter_events,
+    generate_all_anticipation_events,
+    sort_events_chronologically,
+)
+
+
+def test_calendar_pipeline(tmp_path):
+    path = Path("tests/data/sample_calendar.csv")
+    events = read_csv_calendar(path)
+    assert len(events) == 3
+
+    filtered = filter_events(events)
+    # CHF event excluded, so expect 2
+    assert len(filtered) == 2
+
+    anticipations = generate_all_anticipation_events(filtered, hours=(1, 2))
+    # 2 events *2 anticipation =4
+    assert len(anticipations) == 4
+
+    combined = sort_events_chronologically(filtered + anticipations)
+    times = [e.time for e in combined]
+    assert times == sorted(times)

--- a/tests/test_placeholder_tools.py
+++ b/tests/test_placeholder_tools.py
@@ -1,0 +1,50 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+
+
+def run_tool(name, *args):
+    """Run a tool script from the tools directory and return stdout."""
+    cmd = [sys.executable, str(TOOLS_DIR / name), *map(str, args)]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def test_trading_framework_scan():
+    out = run_tool("trading_framework_scan.py", "bundle")
+    assert json.loads(out) == {"frameworks": []}
+
+
+def test_detect_trading_issues():
+    out = run_tool("detect_trading_issues.py", "bundle")
+    assert json.loads(out) == {"issues": []}
+
+
+def test_map_trading_remediations():
+    out = run_tool("map_trading_remediations.py", "findings", "bundle")
+    assert json.loads(out) == {"remediations": []}
+
+
+def test_apply_trading_patch():
+    out = run_tool("apply_trading_patch.py", "bundle", "plan")
+    assert json.loads(out) == {"artifact": "trading_system_vN+1"}
+
+
+def test_run_trading_validation():
+    out = run_tool("run_trading_validation.py", "artifact")
+    data = json.loads(out)
+    assert data["gates"] == {"A": True, "B": True, "C": True}
+
+
+def test_compute_trading_metrics():
+    out = run_tool("compute_trading_metrics.py", "validation", "findings")
+    data = json.loads(out)
+    assert data["trading_system_quality"] == 100
+
+
+def test_make_trading_diff():
+    out = run_tool("make_trading_diff.py", "vN", "vN1")
+    assert out == ""

--- a/tests/test_strategy_id.py
+++ b/tests/test_strategy_id.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import strategy_id
+
+
+def test_strategy_id_deterministic():
+    base = strategy_id.generate("US", "High")
+    again = strategy_id.generate("US", "High")
+    assert base == again
+
+
+def test_anticipation_offset():
+    base = strategy_id.generate("US", "High")
+    ant = strategy_id.generate("US", "High", anticipation=True)
+    assert ant == base + 1000

--- a/tests/test_ui_economic_calendar_tab.py
+++ b/tests/test_ui_economic_calendar_tab.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from ui_economic_calendar_tab import EconomicCalendarTab
+
+
+def test_sections_present():
+    tab = EconomicCalendarTab()
+    for name in tab.section_names():
+        assert hasattr(tab, name)

--- a/tools/apply_trading_patch.py
+++ b/tools/apply_trading_patch.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Placeholder apply_trading_patch tool.
+
+Simulates applying a patch by returning a hardcoded artifact pointer. The
+supplied inputs are ignored so that downstream tooling has a deterministic
+interface during early development.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder apply_trading_patch tool")
+    parser.add_argument("trading_system_bundle", help="Path to trading system bundle (unused)")
+    parser.add_argument("blue_plan", help="Path to remediation plan (unused)")
+    parser.add_argument("-o", "--output", help="Optional output JSON file; defaults to stdout")
+    args = parser.parse_args()
+
+    result = {"artifact": "trading_system_vN+1"}
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compute_trading_metrics.py
+++ b/tools/compute_trading_metrics.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Placeholder compute_trading_metrics tool.
+
+Outputs a fixed set of metrics regardless of the supplied validation results or
+findings. This keeps the interface stable for tests while real metric
+calculation is developed.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder compute_trading_metrics tool")
+    parser.add_argument("validation_results", help="Path to validation results JSON (unused)")
+    parser.add_argument("red_findings", help="Path to red findings JSON (unused)")
+    parser.add_argument("-o", "--output", help="Optional output JSON file; defaults to stdout")
+    args = parser.parse_args()
+
+    result = {
+        "trading_system_quality": 100,
+        "critical_blockers_remaining": 0,
+        "major_issues_remaining": 0,
+        "average_execution_latency_ms": 0,
+        "bridge_reliability_score": 100,
+        "regulatory_compliance_score": 100,
+        "improvement_rate": "0%",
+    }
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/detect_trading_issues.py
+++ b/tools/detect_trading_issues.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Placeholder detect_trading_issues tool.
+
+Returns an empty set of issues regardless of the supplied bundle. Real
+implementations should perform static analysis or runtime checks on the trading
+system.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder detect_trading_issues tool")
+    parser.add_argument("trading_system_bundle", help="Path to the trading system bundle (unused)")
+    parser.add_argument("-o", "--output", help="Optional output JSON file; defaults to stdout")
+    args = parser.parse_args()
+
+    result = {"issues": []}
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/make_trading_diff.py
+++ b/tools/make_trading_diff.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Placeholder make_trading_diff tool.
+
+Generates an empty unified diff regardless of the artifacts supplied so test
+pipelines can exercise a diff step.
+"""
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder make_trading_diff tool")
+    parser.add_argument("artifact_vN", help="Original artifact (unused)")
+    parser.add_argument("artifact_vN1", help="Updated artifact (unused)")
+    parser.add_argument("-o", "--output", help="Optional output diff file; defaults to stdout")
+    args = parser.parse_args()
+
+    diff_text = ""  # No differences in placeholder implementation
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(diff_text)
+    else:
+        print(diff_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/map_trading_remediations.py
+++ b/tools/map_trading_remediations.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Placeholder map_trading_remediations tool.
+
+Returns an empty remediation plan for any supplied findings or system bundle,
+providing a stable interface while remediation logic is developed.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder map_trading_remediations tool")
+    parser.add_argument("red_findings", help="Path to findings report (unused)")
+    parser.add_argument("trading_system_bundle", help="Path to trading system bundle (unused)")
+    parser.add_argument("-o", "--output", help="Optional output JSON file; defaults to stdout")
+    args = parser.parse_args()
+
+    result = {"remediations": []}
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_trading_validation.py
+++ b/tools/run_trading_validation.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Placeholder run_trading_validation tool.
+
+Ignores the provided artifact and returns passing results for every validation
+category. This lets other tooling proceed before real validation logic exists.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder run_trading_validation tool")
+    parser.add_argument("artifact", help="Path to updated trading system artifact (unused)")
+    parser.add_argument("-o", "--output", help="Optional output JSON file; defaults to stdout")
+    args = parser.parse_args()
+
+    result = {
+        "mql4_compilation": "pass",
+        "python_services": "pass",
+        "bridge_connectivity": "pass",
+        "database_integrity": "pass",
+        "risk_parameters": "pass",
+        "security_scan": "pass",
+        "performance_benchmarks": "pass",
+        "fixes_applied": 0,
+        "trading_issues_resolved": 0,
+        "new_issues": 0,
+        "gates": {"A": True, "B": True, "C": True},
+    }
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trading_framework_scan.py
+++ b/tools/trading_framework_scan.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Placeholder trading_framework_scan tool.
+
+This stub returns an empty framework report regardless of the bundle provided
+so dependent workflows can execute during development.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Placeholder trading_framework_scan tool")
+    parser.add_argument("trading_system_bundle", help="Path to the trading system bundle (unused)")
+    parser.add_argument("-o", "--output", help="Optional output JSON file; defaults to stdout")
+    args = parser.parse_args()
+
+    result = {"frameworks": []}
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ui_components/__init__.py
+++ b/ui_components/__init__.py
@@ -1,0 +1,5 @@
+"""UI component placeholders for economic calendar tab.
+
+Each module provides minimal functionality so the interface can
+instantiate and reference the required sections.
+"""

--- a/ui_components/anticipation_config.py
+++ b/ui_components/anticipation_config.py
@@ -1,0 +1,10 @@
+"""Anticipation Configuration component placeholder."""
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class AnticipationConfig:
+    """Stores anticipation hours and impact filters."""
+    hours: List[int] = field(default_factory=lambda: [1, 2, 4, 8, 12])
+    impacts: List[str] = field(default_factory=lambda: ["High", "Medium"])

--- a/ui_components/data_management.py
+++ b/ui_components/data_management.py
@@ -1,0 +1,12 @@
+"""Calendar Data Management component placeholder."""
+from dataclasses import dataclass
+
+
+@dataclass
+class DataManagement:
+    """Placeholder for file upload/import status widgets."""
+    imported_rows: int = 0
+
+    def record_import(self, rows: int) -> None:
+        """Record number of imported rows."""
+        self.imported_rows = rows

--- a/ui_components/filtering_processing.py
+++ b/ui_components/filtering_processing.py
@@ -1,0 +1,10 @@
+"""Filtering and Processing component placeholder."""
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class FilteringProcessing:
+    """Stores currency mappings and exclusions."""
+    currency_map: Dict[str, str] = None
+    exclude_chf: bool = True

--- a/ui_components/monitoring.py
+++ b/ui_components/monitoring.py
@@ -1,0 +1,17 @@
+"""Real-time monitoring component placeholder."""
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+
+@dataclass
+class Monitoring:
+    """Tracks upcoming events and countdown."""
+    next_event: datetime | None = None
+
+    def update_next_event(self, event_time: datetime) -> None:
+        self.next_event = event_time
+
+    def seconds_until(self) -> int:
+        if self.next_event is None:
+            return -1
+        return max(0, int((self.next_event - datetime.utcnow()).total_seconds()))

--- a/ui_components/processing_engine.py
+++ b/ui_components/processing_engine.py
@@ -1,0 +1,10 @@
+"""Processing engine component placeholder."""
+from dataclasses import dataclass
+
+
+@dataclass
+class ProcessingEngine:
+    """Tracks pipeline stage counts."""
+    raw_count: int = 0
+    filtered_count: int = 0
+    output_count: int = 0

--- a/ui_components/signal_generation.py
+++ b/ui_components/signal_generation.py
@@ -1,0 +1,14 @@
+"""Signal generation component placeholder."""
+from dataclasses import dataclass
+from typing import List, Dict
+
+
+@dataclass
+class SignalGeneration:
+    """Stores generated signals."""
+    signals: List[Dict[str, str]] = None
+
+    def record(self, signal: Dict[str, str]) -> None:
+        if self.signals is None:
+            self.signals = []
+        self.signals.append(signal)

--- a/ui_components/strategy_ids.py
+++ b/ui_components/strategy_ids.py
@@ -1,0 +1,17 @@
+"""Strategy ID component placeholder."""
+from dataclasses import dataclass, field
+from typing import List
+from strategy_id import generate
+
+
+@dataclass
+class StrategyIDs:
+    """Manages generated strategy IDs."""
+    ids: List[int] = field(default_factory=list)
+
+    def add(self, country: str, impact: str, anticipation: bool = False) -> int:
+        sid = generate(country, impact, anticipation)
+        if sid in self.ids:
+            raise ValueError("duplicate strategy id")
+        self.ids.append(sid)
+        return sid

--- a/ui_economic_calendar_tab.py
+++ b/ui_economic_calendar_tab.py
@@ -1,0 +1,39 @@
+"""Simplified Economic Calendar UI tab scaffold.
+
+This module stitches together placeholder UI components defined in
+``ui_components``. The real application would render these sections in a
+GUI toolkit, but for testing purposes we merely ensure that each section
+is instantiated and accessible.
+"""
+from ui_components.data_management import DataManagement
+from ui_components.anticipation_config import AnticipationConfig
+from ui_components.filtering_processing import FilteringProcessing
+from ui_components.strategy_ids import StrategyIDs
+from ui_components.processing_engine import ProcessingEngine
+from ui_components.signal_generation import SignalGeneration
+from ui_components.monitoring import Monitoring
+
+
+class EconomicCalendarTab:
+    """Container that exposes all calendar tab sections."""
+
+    def __init__(self) -> None:
+        self.data_management = DataManagement()
+        self.anticipation_config = AnticipationConfig()
+        self.filtering_processing = FilteringProcessing()
+        self.strategy_ids = StrategyIDs()
+        self.processing_engine = ProcessingEngine()
+        self.signal_generation = SignalGeneration()
+        self.monitoring = Monitoring()
+
+    def section_names(self):
+        """Return the list of available section attribute names."""
+        return [
+            "data_management",
+            "anticipation_config",
+            "filtering_processing",
+            "strategy_ids",
+            "processing_engine",
+            "signal_generation",
+            "monitoring",
+        ]


### PR DESCRIPTION
## Summary
- scaffold placeholder trading tools (`trading_framework_scan`, `detect_trading_issues`, `map_trading_remediations`, `apply_trading_patch`, `run_trading_validation`, `compute_trading_metrics`, `make_trading_diff`) returning fixed outputs for early pipeline wiring
- add test suite verifying each tool’s deterministic behavior
- scaffold economic calendar tab and related processing utilities
- document repository usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91a57e444832f988052307ca5efbe