### PR TITLE
Launch MT4 when starting desktop GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@ Generated from BU_* briefs: diagnostics schema, tests, CI, and app stubs.
 - `settings.json` – example configuration
 - Includes scaffolding for conditional probability signals, currency strength
   analytics, and transport failover examples used in tests
+
+## Launching the desktop GUI with MetaTrader 4
+
+Running the desktop application also launches a MetaTrader 4 terminal if the
+`terminal.exe` executable can be located. The launcher checks the `MT4_PATH`
+environment variable first and falls back to a couple of common installation
+paths on Windows when running on that platform.
+
+Two helper scripts are provided which can be placed on the desktop and used as
+shortcuts:
+
+- `launch_gui.bat` – Windows batch file
+- `launch_gui.sh` – POSIX shell script
+
+Both scripts simply execute `python -m eafix.apps.desktop.main` which in turn
+starts MetaTrader 4 (if available) and then the Python GUI.

--- a/launch_gui.bat
+++ b/launch_gui.bat
@@ -1,0 +1,2 @@
+@echo off
+python -m eafix.apps.desktop.main %*

--- a/launch_gui.sh
+++ b/launch_gui.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -m eafix.apps.desktop.main "$@"

--- a/src/eafix/apps/desktop/main.py
+++ b/src/eafix/apps/desktop/main.py
@@ -1,14 +1,72 @@
-try:
+"""Entry point for the desktop UI.
+
+When the desktop GUI is launched we also want to spawn a MetaTrader 4
+terminal so the two applications are available side by side.  The MT4
+executable location can be supplied via the ``MT4_PATH`` environment
+variable.  If it is not provided we try a couple of common install
+locations on Windows.  Failing that, a warning is printed but the GUI
+still launches.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+try:  # PySide6 is optional for environments running the tests
     from PySide6.QtWidgets import QApplication
-except Exception:
+except Exception:  # pragma: no cover - handled gracefully at runtime
     QApplication = None
 
-def main():
+logger = logging.getLogger(__name__)
+
+
+def launch_mt4() -> None:
+    """Best-effort launch of the MetaTrader 4 terminal.
+
+    The function first checks the ``MT4_PATH`` environment variable. If it is
+    not set, typical installation paths on Windows are probed. If an executable
+    cannot be found the user is informed but no exception is raised.
+    """
+
+    candidates: list[Path] = []
+
+    env_path = os.environ.get("MT4_PATH")
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    if os.name == "nt":  # only probe standard install locations on Windows
+        candidates.extend(
+            [
+                Path(r"C:/Program Files/MetaTrader 4/terminal.exe"),
+                Path(r"C:/Program Files (x86)/MetaTrader 4/terminal.exe"),
+            ]
+        )
+
+    for candidate in candidates:
+        if candidate.is_file():
+            try:
+                subprocess.Popen([str(candidate)])
+            except OSError as exc:  # pragma: no cover - depends on OS
+                logger.warning("Failed to launch MT4 at %s: %s", candidate, exc)
+            return
+
+    logger.warning(
+        "MT4 executable not found. Set the MT4_PATH environment variable to the path of terminal.exe."
+    )
+
+
+def main() -> None:
     if QApplication is None:
-        print("PySide6 is not installed. Install PySide6 to run the desktop app.")
+        logger.error("PySide6 is not installed. Install PySide6 to run the desktop app.")
         return
+    launch_mt4()
     from .ui_shell import launch_ui
+
     launch_ui()
+
 
 if __name__ == "__main__":
     main()

--- a/src/eafix/apps/desktop/ui_shell.py
+++ b/src/eafix/apps/desktop/ui_shell.py
@@ -1,12 +1,24 @@
+import logging
+
 try:
-    from PySide6.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget, QWidget, QVBoxLayout
+    from PySide6.QtWidgets import (
+        QApplication,
+        QMainWindow,
+        QLabel,
+        QDockWidget,
+        QWidget,
+        QVBoxLayout,
+    )
 except Exception:
     QApplication = None
     QMainWindow = object
 
-def launch_ui():
+logger = logging.getLogger(__name__)
+
+
+def launch_ui() -> None:
     if QApplication is None:
-        print("PySide6 is not installed. Install PySide6 to run the desktop app.")
+        logger.error("PySide6 is not installed. Install PySide6 to run the desktop app.")
         return
     app = QApplication([])
     win = QMainWindow()

--- a/tests/test_desktop_launch.py
+++ b/tests/test_desktop_launch.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from eafix.apps.desktop.main import launch_mt4
+
+
+def test_launch_mt4_uses_env_path(monkeypatch):
+    fake_path = "/fake/terminal.exe"
+    monkeypatch.setenv("MT4_PATH", fake_path)
+
+    with patch("eafix.apps.desktop.main.Path.is_file", return_value=True), \
+            patch("eafix.apps.desktop.main.subprocess.Popen") as popen:
+        launch_mt4()
+        popen.assert_called_once_with([fake_path])
+


### PR DESCRIPTION
## Summary
- launch MetaTrader 4 alongside the GUI using logging and Windows-specific defaults
- convert desktop UI to use logging instead of prints
- update tests and docs for MT4 launch behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9a89be810832f89e4483158ea0894