### PR TITLE
Add Forex Factory economic calendar utilities

### DIFF
--- a/src/eafix/__init__.py
+++ b/src/eafix/__init__.py
@@ -6,11 +6,12 @@ the package.
 """
 
 from . import conditional_signals, currency_strength, indicator_engine, signals
-from . import strength_feed, transport_integrations
+from . import economic_calendar, strength_feed, transport_integrations
 
 __all__ = [
     "conditional_signals",
     "currency_strength",
+    "economic_calendar",
     "indicator_engine",
     "signals",
     "strength_feed",

--- a/src/eafix/economic_calendar.py
+++ b/src/eafix/economic_calendar.py
@@ -1,0 +1,112 @@
+"""Utilities for fetching and displaying Forex Factory economic calendar data."""
+
+from __future__ import annotations
+
+import random
+import re
+import time
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from urllib.request import urlopen
+
+
+@dataclass
+class CalendarEventResult:
+    """Parsed values for a single economic calendar event."""
+
+    actual: Optional[float]
+    forecast: Optional[float]
+    previous: Optional[float]
+    diff_forecast: Optional[float]
+    diff_previous: Optional[float]
+
+
+def _extract_value(html: str, cls: str) -> Optional[float]:
+    """Return the numeric value contained in ``<td class=cls>``.
+
+    Values are normalized by removing percent signs and commas.  If the class is
+    not found or cannot be parsed, ``None`` is returned.
+    """
+
+    pattern = rf"<td[^>]*class=[\"']{cls}[\"'][^>]*>(.*?)</td>"
+    match = re.search(pattern, html, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return None
+    text = re.sub("<.*?>", "", match.group(1))
+    text = text.strip().replace("%", "").replace(",", "")
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def parse_event_page(html: str) -> CalendarEventResult:
+    """Parse *html* from a Forex Factory event page.
+
+    The returned object contains the ``actual``, ``forecast`` and ``previous``
+    values along with simple differences from ``actual``.
+    """
+
+    actual = _extract_value(html, "actual")
+    forecast = _extract_value(html, "forecast")
+    previous = _extract_value(html, "previous")
+
+    diff_forecast = actual - forecast if actual is not None and forecast is not None else None
+    diff_previous = actual - previous if actual is not None and previous is not None else None
+
+    return CalendarEventResult(actual, forecast, previous, diff_forecast, diff_previous)
+
+
+def fetch_event_result(
+    event_url: str,
+    delay_range: Tuple[int, int] = (120, 300),
+    poll_interval: int = 15,
+    max_attempts: int = 20,
+) -> CalendarEventResult:
+    """Fetch and parse a Forex Factory event page after a short delay.
+
+    After waiting a random amount of time within ``delay_range`` (in seconds),
+    the event page is polled up to ``max_attempts`` times separated by
+    ``poll_interval`` seconds.  Polling stops as soon as the ``actual`` value is
+    available and differs from the last seen value.  Each update emits a
+    terminal bell so users are alerted when new information arrives.
+    """
+
+    wait_seconds = random.randint(*delay_range)
+    time.sleep(wait_seconds)
+
+    last_actual: Optional[float] = None
+    result: CalendarEventResult | None = None
+
+    for _ in range(max_attempts):
+        with urlopen(event_url, timeout=10) as resp:  # nosec B310
+            html = resp.read().decode("utf-8", errors="replace")
+
+        result = parse_event_page(html)
+
+        if result.actual is not None and result.actual != last_actual:
+            print("\a", end="")  # alert user that new information is available
+            return result
+
+        last_actual = result.actual
+        time.sleep(poll_interval)
+
+    # If we exit the loop without returning, provide the last parsed result
+    # (which may still have ``actual`` set to ``None``).
+    return result if result is not None else CalendarEventResult(None, None, None, None, None)
+
+
+def format_event_result(result: CalendarEventResult) -> str:
+    """Return a human readable summary of *result* values."""
+
+    actual = result.actual if result.actual is not None else "n/a"
+    forecast = result.forecast if result.forecast is not None else "n/a"
+    previous = result.previous if result.previous is not None else "n/a"
+    diff_forecast = f"{result.diff_forecast:+}" if result.diff_forecast is not None else "n/a"
+    diff_previous = f"{result.diff_previous:+}" if result.diff_previous is not None else "n/a"
+
+    return (
+        f"Actual: {actual} | Forecast: {forecast} | Previous: {previous}\n"
+        f"Δ Forecast: {diff_forecast} | Δ Previous: {diff_previous}"
+    )

--- a/tests/test_economic_calendar.py
+++ b/tests/test_economic_calendar.py
@@ -1,0 +1,84 @@
+import pytest
+
+from eafix import economic_calendar
+from eafix.economic_calendar import (
+    CalendarEventResult,
+    fetch_event_result,
+    format_event_result,
+    parse_event_page,
+)
+
+SAMPLE_HTML = """
+<table>
+<tr>
+<td class="actual">1.5%</td>
+<td class="forecast">1.2%</td>
+<td class="previous">1.0%</td>
+</tr>
+</table>
+"""
+
+def test_parse_event_page():
+    result = parse_event_page(SAMPLE_HTML)
+    assert result.actual == 1.5
+    assert result.forecast == 1.2
+    assert result.previous == 1.0
+    assert result.diff_forecast == pytest.approx(0.3)
+    assert result.diff_previous == pytest.approx(0.5)
+
+
+def test_format_event_result():
+    result = CalendarEventResult(1.5, 1.2, 1.0, 0.3, 0.5)
+    msg = format_event_result(result)
+    assert "Actual: 1.5" in msg
+    assert "Forecast: 1.2" in msg
+    assert "Previous: 1.0" in msg
+    assert "Δ Forecast: +0.3" in msg
+    assert "Δ Previous: +0.5" in msg
+
+
+def test_fetch_event_result_polls_until_actual(monkeypatch):
+    html_no_actual = """
+    <table><tr>
+    <td class="actual"></td>
+    <td class="forecast">1.2%</td>
+    <td class="previous">1.0%</td>
+    </tr></table>
+    """
+
+    html_with_actual = """
+    <table><tr>
+    <td class="actual">1.5%</td>
+    <td class="forecast">1.2%</td>
+    <td class="previous">1.0%</td>
+    </tr></table>
+    """
+
+    responses = [html_no_actual, html_with_actual]
+
+    class DummyResp:
+        def __init__(self, html):
+            self.html = html
+
+        def read(self):
+            return self.html.encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def fake_urlopen(url, timeout=10):  # noqa: D401 - signature matches real function
+        return DummyResp(responses.pop(0))
+
+    beeps = []
+
+    monkeypatch.setattr(economic_calendar, "urlopen", fake_urlopen)
+    monkeypatch.setattr(economic_calendar.random, "randint", lambda a, b: 0)
+    monkeypatch.setattr(economic_calendar.time, "sleep", lambda s: None)
+    monkeypatch.setattr("builtins.print", lambda msg="", end="\n": beeps.append(msg))
+
+    result = fetch_event_result("http://example.com", delay_range=(0, 0), poll_interval=0, max_attempts=2)
+    assert result.actual == 1.5
+    assert "\a" in beeps


### PR DESCRIPTION
## Summary
- poll Forex Factory event pages until actual value is published and emit terminal bell on updates
- format and expose actual/forecast/previous differences with signs
- test event parsing, formatting, and polling behaviors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa183258832f9db2ae0303fa1d45