### PR TITLE
Add currency strength tab to desktop UI

### DIFF
--- a/src/eafix/apps/desktop/ui_shell.py
+++ b/src/eafix/apps/desktop/ui_shell.py
@@ -1,8 +1,45 @@
 try:
-    from PySide6.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget, QWidget, QVBoxLayout
+    from PySide6.QtWidgets import (
+        QApplication,
+        QMainWindow,
+        QLabel,
+        QDockWidget,
+        QWidget,
+        QVBoxLayout,
+        QTabWidget,
+    )
 except Exception:
     QApplication = None
     QMainWindow = object
+
+STRENGTH_INDICATORS = ["RSI", "Stochastic", "Z-Score"]
+
+
+def _build_workspace_tab() -> QWidget:
+    """Create the default workspace tab."""
+    tab = QWidget()
+    layout = QVBoxLayout(tab)
+    layout.addWidget(QLabel("Central workspace — YAML editor would live here."))
+    return tab
+
+
+def _build_strength_tab() -> QWidget:
+    """Create a tab displaying currency strength indicators."""
+    tab = QWidget()
+    layout = QVBoxLayout(tab)
+    layout.addWidget(QLabel("Currency strength indicators"))
+    for name in STRENGTH_INDICATORS:
+        layout.addWidget(QLabel(name))
+    return tab
+
+
+def create_central_widget() -> QTabWidget:
+    """Construct the central tab widget for the main window."""
+    tabs = QTabWidget()
+    tabs.addTab(_build_workspace_tab(), "Workspace")
+    tabs.addTab(_build_strength_tab(), "Strength")
+    return tabs
+
 
 def launch_ui():
     if QApplication is None:
@@ -12,11 +49,8 @@ def launch_ui():
     win = QMainWindow()
     win.setWindowTitle("APF Desktop (stub)")
 
-    # Central widget
-    central = QWidget()
-    layout = QVBoxLayout(central)
-    layout.addWidget(QLabel("Central workspace — YAML editor would live here."))
-    win.setCentralWidget(central)
+    # Central widget with tabs
+    win.setCentralWidget(create_central_widget())
 
     # Problems dock
     dock = QDockWidget("Problems")

--- a/tests/test_ui_strength_tab.py
+++ b/tests/test_ui_strength_tab.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication
+from eafix.apps.desktop.ui_shell import STRENGTH_INDICATORS, create_central_widget
+
+
+def test_strength_tab_present():
+    app = QApplication.instance() or QApplication([])
+    central = create_central_widget()
+    tab_names = [central.tabText(i) for i in range(central.count())]
+    assert "Strength" in tab_names
+    strength_widget = central.widget(tab_names.index("Strength"))
+    layout = strength_widget.layout()
+    labels = [layout.itemAt(i).widget().text() for i in range(layout.count())]
+    for name in STRENGTH_INDICATORS:
+        assert name in labels
+    app.quit()
+


### PR DESCRIPTION
## Summary
- Add tabbed central widget to desktop UI
- Include dedicated "Strength" tab showing currency strength indicators
- Centralize indicator list via `STRENGTH_INDICATORS`
- Test for presence of new tab and indicator labels (skipped if PySide6 unavailable)

## Testing
- `pytest`
- `pip install PySide6` (failed: Could not find a version that satisfies the requirement PySide6: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b9aaef2790832faa9a102ba8f9b599