### PR TITLE
Add instant Forex Factory calendar importer

### DIFF
--- a/src/eafix/__init__.py
+++ b/src/eafix/__init__.py
@@ -5,8 +5,14 @@ simply import them from :mod:`eafix` without knowing the internal layout of
 the package.
 """
 
-from . import conditional_signals, currency_strength, indicator_engine, signals
+from . import (
+    conditional_signals,
+    currency_strength,
+    indicator_engine,
+    signals,
+)
 from . import strength_feed, transport_integrations
+from .forex_factory_calendar import fetch_calendar
 
 __all__ = [
     "conditional_signals",
@@ -15,6 +21,7 @@ __all__ = [
     "signals",
     "strength_feed",
     "transport_integrations",
+    "fetch_calendar",
 ]
 
 # Basic package metadata; the version is intentionally static for the scaffold

--- a/src/eafix/forex_factory_calendar.py
+++ b/src/eafix/forex_factory_calendar.py
@@ -1,0 +1,55 @@
+"""Forex Factory calendar importer.
+
+This module provides a small helper to download the weekly economic
+calendar from Forex Factory and return only upcoming events.  The real
+calendar feed is updated daily; this helper allows users to trigger an
+instant import that ignores past events.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from urllib.request import urlopen
+
+# Public JSON feed provided by Forex Factory.
+DEFAULT_CALENDAR_URL = "https://nfs.faireconomy.media/ff_calendar_thisweek.json"
+
+def fetch_calendar(
+    url: str = DEFAULT_CALENDAR_URL,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Download the Forex Factory calendar and return future events.
+
+    Parameters
+    ----------
+    url:
+        Endpoint returning the calendar JSON.  Defaults to the official
+        Forex Factory feed.
+    now:
+        Reference time used to filter events.  Defaults to the current
+        UTC time.
+
+    Returns
+    -------
+    list[dict]
+        Calendar entries occurring at or after *now*.
+    """
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+
+    with urlopen(url, timeout=10) as resp:  # pragma: no cover - simple I/O
+        data = json.load(resp)
+
+    upcoming: list[dict[str, Any]] = []
+    for event in data:
+        try:
+            ts = datetime.fromtimestamp(int(event["timestamp"]), tz=timezone.utc)
+        except Exception:
+            continue  # skip malformed entries
+        if ts >= now:
+            item = dict(event)
+            item["datetime"] = ts.isoformat()
+            upcoming.append(item)
+    return upcoming

--- a/tests/test_forex_factory_calendar.py
+++ b/tests/test_forex_factory_calendar.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+import json
+from io import BytesIO
+
+from eafix.forex_factory_calendar import fetch_calendar
+
+
+class DummyResponse(BytesIO):
+    def __enter__(self):  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, *exc):  # pragma: no cover - trivial
+        self.close()
+
+
+def test_fetch_calendar_filters_past_events(monkeypatch):
+    data = [
+        {"title": "Old", "timestamp": 1000},
+        {"title": "Upcoming", "timestamp": 3000},
+    ]
+
+    def fake_urlopen(url, *_, **__):
+        return DummyResponse(json.dumps(data).encode("utf-8"))
+
+    monkeypatch.setattr("eafix.forex_factory_calendar.urlopen", fake_urlopen)
+    now = datetime.fromtimestamp(2000, tz=timezone.utc)
+
+    events = fetch_calendar(url="http://example.com", now=now)
+    assert len(events) == 1
+    assert events[0]["title"] == "Upcoming"
+    # ensure the helper adds ISO formatted datetime
+    assert events[0]["datetime"].endswith("+00:00")


### PR DESCRIPTION
## Summary
- add helper to download Forex Factory calendar and filter to future events
- expose calendar importer via top-level package
- test calendar importer filters out past events
- expose fetch_calendar at package root and enforce timeout with modern type hints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac2e7968832fb2f40e313b9ac2ae