### PR TITLE
Add indicator signal toggle panel

### DIFF
--- a/src/eafix/ui_indicator_toggle.py
+++ b/src/eafix/ui_indicator_toggle.py
@@ -1,0 +1,74 @@
+"""Tkinter panel for toggling indicator signals."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Dict
+
+
+class IndicatorTogglePanel(ttk.Frame):
+    """Panel providing checkbuttons to enable/disable indicator signals.
+
+    The widget manages a mapping of indicator names to :class:`~tkinter.BooleanVar`
+    instances.  Each indicator appears as a checkbutton that allows the user to
+    quickly enable or disable whether signals from that indicator should be
+    forwarded.  The panel itself does not implement any signalling logic – it
+    merely tracks the on/off state for consumers to query.
+    """
+
+    def __init__(self, master: tk.Misc):
+        super().__init__(master)
+        self._vars: Dict[str, tk.BooleanVar] = {}
+        self.columnconfigure(0, weight=1)
+
+    # ------------------------------------------------------------------
+    def add_indicator(self, name: str, *, enabled: bool = True) -> None:
+        """Add an indicator toggle to the panel.
+
+        Parameters
+        ----------
+        name:
+            Name of the indicator.
+        enabled:
+            Whether the indicator should start in the enabled state.
+
+        Raises
+        ------
+        ValueError
+            If *name* already exists in the panel.
+        """
+        if name in self._vars:
+            raise ValueError(f"Indicator '{name}' already present")
+        var = tk.BooleanVar(value=enabled)
+        cb = ttk.Checkbutton(self, text=name, variable=var)
+        cb.pack(anchor="w")
+        self._vars[name] = var
+
+    def is_enabled(self, name: str) -> bool:
+        """Return ``True`` if the indicator is currently enabled."""
+        if name not in self._vars:
+            raise KeyError(f"Indicator '{name}' not present")
+        return bool(self._vars[name].get())
+
+    def set_enabled(self, name: str, enabled: bool) -> None:
+        """Programmatically set the enabled state of *name* indicator.
+
+        Raises
+        ------
+        KeyError
+            If *name* does not exist in the panel.
+        """
+        if name not in self._vars:
+            raise KeyError(f"Indicator '{name}' not present")
+        self._vars[name].set(enabled)
+
+
+# Convenience for manual testing ------------------------------------------------
+if __name__ == "__main__":  # pragma: no cover - manual testing
+    root = tk.Tk()
+    panel = IndicatorTogglePanel(root)
+    panel.pack(fill="both", expand=True)
+    panel.add_indicator("RSI")
+    panel.add_indicator("MACD", enabled=False)
+    root.mainloop()

--- a/tests/test_ui_indicator_toggle.py
+++ b/tests/test_ui_indicator_toggle.py
@@ -1,0 +1,37 @@
+import pytest
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - tkinter not installed
+    tk = None
+
+from eafix.ui_indicator_toggle import IndicatorTogglePanel
+
+
+@pytest.mark.skipif(tk is None, reason="Tkinter not installed")
+def test_indicator_toggle_states():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter cannot open a display")
+    root.withdraw()
+    panel = IndicatorTogglePanel(root)
+    panel.add_indicator("RSI")
+    panel.add_indicator("MACD", enabled=False)
+
+    with pytest.raises(ValueError):
+        panel.add_indicator("RSI")
+
+    assert panel.is_enabled("RSI") is True
+    assert panel.is_enabled("MACD") is False
+
+    panel.set_enabled("MACD", True)
+    assert panel.is_enabled("MACD") is True
+
+    with pytest.raises(KeyError):
+        panel.is_enabled("UNKNOWN")
+
+    with pytest.raises(KeyError):
+        panel.set_enabled("UNKNOWN", True)
+
+    root.destroy()


### PR DESCRIPTION
## Summary
- refine `IndicatorTogglePanel` to raise errors when toggles are missing or duplicated
- extend tests for duplicate add and missing indicator access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac9a3548832fbdb85d31a2278f9e