### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest jsonschema
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running tests on Python 3.9–3.11
- cache pip dependencies for faster runs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9e307d9fc832f8c975f03aeac9bb1