### PR TITLE
Implement guardian agents and indicator metrics

### DIFF
--- a/src/eafix/guardian/agents/compliance_agent.py
+++ b/src/eafix/guardian/agents/compliance_agent.py
@@ -1,9 +1,36 @@
-"""Compliance agent placeholder."""
+"""Minimal compliance agent used by tests.
 
-from dataclasses import dataclass
+The production system forwards audit logs to a central compliance service.
+For our purposes we merely need a way to capture log messages so that unit
+tests can assert on them.  The :class:`ComplianceAgent` stores messages in
+memory with a timestamp.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
 
 
 @dataclass
 class ComplianceAgent:
+    """Collect compliance log messages.
+
+    Messages are kept in the :attr:`logs` attribute.  Each entry is timestamped
+    using :func:`datetime.utcnow` so callers can inspect when the message was
+    recorded.
+    """
+
+    logs: List[str] = field(default_factory=list)
+
     def log(self, message: str) -> None:
-        pass
+        """Record ``message`` in the internal log list."""
+
+        if not isinstance(message, str):  # pragma: no cover - type guard
+            raise TypeError("message must be a string")
+
+        entry = f"{datetime.utcnow().isoformat()} {message}"
+        self.logs.append(entry)
+
+__all__ = ["ComplianceAgent"]

--- a/src/eafix/guardian/agents/learning_agent.py
+++ b/src/eafix/guardian/agents/learning_agent.py
@@ -1,9 +1,54 @@
-"""Learning agent placeholder."""
+"""Lightweight in-memory learning agent.
 
-from dataclasses import dataclass
+The real project uses a considerably more sophisticated learning subsystem
+that persists events and performs statistical analysis.  For the purposes of
+the tests in this kata we only require a tiny portion of this behaviour: the
+ability to record events in order and make them available for later
+inspection.  The :class:`LearningAgent` below therefore keeps a simple list of
+events and performs basic validation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+import copy
+import time
 
 
 @dataclass
 class LearningAgent:
-    def record(self, event: dict) -> None:
-        pass
+    """Collect events that may be used for off-line learning.
+
+    The agent stores a chronological list of event dictionaries.  Each call to
+    :meth:`record` accepts a mapping and stores a defensive copy augmented with
+    a ``timestamp`` key if one is not already present.  The stored ``events``
+    attribute can then be inspected by tests or other components.
+    """
+
+    events: List[Dict[str, object]] = field(default_factory=list)
+
+    def record(self, event: Dict[str, object]) -> None:
+        """Record *event* for later analysis.
+
+        Parameters
+        ----------
+        event:
+            Mapping describing what happened.  It must be a dictionary so the
+            contents can be serialised and copied safely.
+        """
+
+        if not isinstance(event, dict):  # pragma: no cover - type guard
+            raise TypeError("event must be a dictionary")
+
+        # Make a defensive copy so callers cannot mutate our history after the
+        # fact.  ``deepcopy`` handles nested structures gracefully.
+        data = copy.deepcopy(event)
+
+        # Ensure a timestamp exists so events are ordered even when the caller
+        # forgets to add one.
+        data.setdefault("timestamp", time.time())
+
+        self.events.append(data)
+
+__all__ = ["LearningAgent"]

--- a/src/eafix/guardian/guardian_implementation.py
+++ b/src/eafix/guardian/guardian_implementation.py
@@ -1,25 +1,60 @@
-"""Guardian orchestrator placeholder.
+"""Simplified implementation of the guardian orchestrator.
 
-This module defines :class:`GuardianOrchestrator` which coordinates
-health checks and remediation actions.  The real system would implement a
-sophisticated rule engine; here we only provide hooks with TODO markers
-so tests can import the module.
+The project this repository is based on contains an extensive "guardian"
+sub‑system responsible for coordinating health checks and remediation actions.
+Only a tiny portion of that functionality is required for the exercises in this
+kata: the ability to run a basic check and to forward events and compliance log
+messages to optional sub‑agents.  The implementation below purposely keeps the
+behaviour minimal while providing a clean, testable API.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from .agents.learning_agent import LearningAgent
+from .agents.compliance_agent import ComplianceAgent
 
 
 @dataclass
 class GuardianOrchestrator:
-    """Coordinate health checks and remediation runbooks."""
+    """Coordinate health checks and remediation runbooks.
+
+    Parameters
+    ----------
+    learning_agent:
+        Optional agent used to record events that may later be analysed for
+        continuous learning.
+    compliance_agent:
+        Optional agent used to log compliance related messages.
+    """
+
+    learning_agent: Optional[LearningAgent] = None
+    compliance_agent: Optional[ComplianceAgent] = None
 
     def check(self) -> Dict[str, Any]:
         """Return a static OK result.
 
-        Production code will evaluate constraints and gate logic.
+        Production code will evaluate constraints and gate logic.  The helper
+        method exists so higher level components can depend on a stable API.
         """
+
         return {"status": "OK"}
+
+    # ------------------------------------------------------------------
+    def record_event(self, event: Dict[str, Any]) -> None:
+        """Forward *event* to the learning agent if one is configured."""
+
+        if self.learning_agent is not None:
+            self.learning_agent.record(event)
+
+    def log_compliance(self, message: str) -> None:
+        """Forward a compliance log message to the compliance agent."""
+
+        if self.compliance_agent is not None:
+            self.compliance_agent.log(message)
+
+
+__all__ = ["GuardianOrchestrator"]
 


### PR DESCRIPTION
## Summary
- add real implementations for LearningAgent and ComplianceAgent
- expand GuardianOrchestrator to forward events and compliance logs
- track basic update-rate metrics in IndicatorEngine

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba08898474832fbf11d133ab896646