### PR TITLE
Fix timezone handling in FridayVolSignal

### DIFF
--- a/src/eafix/signals/friday_vol_signal.py
+++ b/src/eafix/signals/friday_vol_signal.py
@@ -37,7 +37,9 @@ class FridayVolSignal:
         self._last_triggered: Dict[str, datetime.date] = {}
 
     def _current_chicago(self, now_utc: Optional[datetime] = None) -> datetime:
-        now_utc = now_utc or datetime.utcnow().replace(tzinfo=UTC)
+        now_utc = now_utc or datetime.utcnow()
+        if now_utc.tzinfo is None:
+            now_utc = now_utc.replace(tzinfo=UTC)
         return now_utc.astimezone(CHI)
 
     def _window_bounds_utc(self, ref_utc: Optional[datetime] = None):

--- a/tests/test_friday_vol_signal.py
+++ b/tests/test_friday_vol_signal.py
@@ -69,3 +69,13 @@ def test_friday_vol_signal_triggers():
     now_utc = datetime(2023, 9, 1, 20, 0, tzinfo=UTC)
     result = signal.evaluate("EURUSD", get_price_at, now_utc)
     assert result and result["type"] == "EXECUTE"
+
+
+def test_naive_datetime_supported():
+    """Evaluate should accept naive UTC datetimes without error."""
+    cfg = FridayVolSignalConfig(percent_threshold=1.0)
+    sig = FridayVolSignal(cfg)
+    get_price = mock_prices_factory(1.0, 1.02)
+    now_naive = datetime(2025, 8, 29, 20, 10, 0)  # same moment as FRI_UTC but naive
+    msg = sig.evaluate("EURUSD", get_price_at=get_price, now_utc=now_naive)
+    assert msg and msg["type"] == "EXECUTE"


### PR DESCRIPTION
## Summary
- ensure `FridayVolSignal` accepts naive UTC datetimes by applying UTC tzinfo before conversion
- add regression test for naive datetime handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba0c231bc8832fa862695ab917d1b7