### PR TITLE
Replace eval-based constraint DSL with safe AST interpreter

### DIFF
--- a/src/eafix/guardian/constraints/dsl.py
+++ b/src/eafix/guardian/constraints/dsl.py
@@ -1,18 +1,105 @@
-"""Tiny DSL parser placeholder for constraints."""
+"""Tiny DSL parser placeholder for constraints.
+
+This module originally used Python's :func:`eval` which allows execution of
+arbitrary code.  To harden the system against code injection the evaluation is
+now performed using the :mod:`ast` module and a very small interpreter that
+supports only a limited subset of Python expressions (boolean operations,
+comparisons and arithmetic on literal values).
+
+The implementation intentionally raises ``ValueError`` for any unsupported
+syntax to avoid accidentally executing unsafe constructs.
+"""
 
 from __future__ import annotations
 
 from typing import Any, Dict
 
+import ast
+import operator
+
+
+_COMPARE_OPS = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+}
+
+_BIN_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+
+
+def _safe_eval(node: ast.AST, context: Dict[str, Any]) -> Any:
+    """Recursively evaluate a subset of Python AST nodes."""
+
+    if isinstance(node, ast.Expression):
+        return _safe_eval(node.body, context)
+
+    if isinstance(node, ast.Constant):
+        return node.value
+
+    if isinstance(node, ast.Name):
+        return context[node.id]
+
+    if isinstance(node, ast.BoolOp):
+        values = [_safe_eval(v, context) for v in node.values]
+        if isinstance(node.op, ast.And):
+            return all(values)
+        if isinstance(node.op, ast.Or):
+            return any(values)
+        raise ValueError("Unsupported boolean operator")
+
+    if isinstance(node, ast.UnaryOp):
+        operand = _safe_eval(node.operand, context)
+        if isinstance(node.op, ast.USub):
+            return -operand
+        if isinstance(node.op, ast.UAdd):
+            return +operand
+        if isinstance(node.op, ast.Not):
+            return not operand
+        raise ValueError("Unsupported unary operator")
+
+    if isinstance(node, ast.BinOp):
+        left = _safe_eval(node.left, context)
+        right = _safe_eval(node.right, context)
+        op_type = type(node.op)
+        if op_type in _BIN_OPS:
+            return _BIN_OPS[op_type](left, right)
+        raise ValueError("Unsupported binary operator")
+
+    if isinstance(node, ast.Compare):
+        left = _safe_eval(node.left, context)
+        for op, comparator in zip(node.ops, node.comparators):
+            right = _safe_eval(comparator, context)
+            op_type = type(op)
+            if op_type not in _COMPARE_OPS:
+                raise ValueError("Unsupported comparison operator")
+            if not _COMPARE_OPS[op_type](left, right):
+                return False
+            left = right
+        return True
+
+    raise ValueError(f"Unsupported expression: {type(node).__name__}")
+
 
 def evaluate(expression: str, context: Dict[str, Any]) -> bool:
-    """Very small eval wrapper used only for tests.
+    """Safely evaluate a tiny expression language using a restricted AST.
 
-    WARNING: uses Python's eval and therefore must not be used in
-    production without proper sandboxing.
+    Any parsing or evaluation error results in ``False`` to mirror the previous
+    behaviour where exceptions were swallowed.
     """
+
     try:
-        return bool(eval(expression, {}, context))
+        tree = ast.parse(expression, mode="eval")
+        return bool(_safe_eval(tree, context))
     except Exception:
         return False
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,0 +1,20 @@
+import pathlib
+import sys
+import pytest
+
+# Allow running tests without installing the package
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from eafix.guardian.constraints.dsl import evaluate
+
+
+def test_evaluate_boolean_expression():
+    context = {"x": 2, "y": 5}
+    assert evaluate("x < 5 and y >= 5", context) is True
+    assert evaluate("x > 10 or y < 3", context) is False
+
+
+def test_evaluate_rejects_unsafe_expression():
+    # Attempting to access builtins or call functions should fail
+    assert evaluate("__import__('os').system('echo hi')", {}) is False
+    assert evaluate("(lambda: 1)()", {}) is False


### PR DESCRIPTION
## Summary
- eliminate dynamic code execution from the constraint DSL by replacing `eval` with a restricted AST interpreter
- add tests verifying boolean expressions and preventing unsafe constructs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba115a925c832f8cb3fbb7801068f5