### PR TITLE
Use log returns for currency strength

### DIFF
--- a/src/eafix/currency_strength.py
+++ b/src/eafix/currency_strength.py
@@ -1,34 +1,60 @@
-"""Currency strength calculator.
+"""Currency strength utilities.
 
-This module provides a simple implementation that aggregates percentage
-changes per currency.  A positive move in the base currency increases its
-strength while the quote currency decreases.  The API mirrors what the
-real trading system would expect but avoids heavy dependencies.
+The original project used plain percentage changes to aggregate currency
+strength.  This module upgrades that logic to work with *log returns*,
+which are additive across time and symmetric for up and down moves.  A
+positive move in the base currency increases its strength while the quote
+currency decreases.  The API mirrors what the real trading system would
+expect but avoids heavy dependencies.
 """
 
 from __future__ import annotations
 
 from collections import defaultdict
+import math
 from typing import Dict, Iterable, Mapping
 
 
-def calc_currency_strength(pair_changes: Mapping[str, float]) -> Dict[str, float]:
-    """Return currency strength dictionary from pair percentage changes.
+def log_return(price_now: float, price_then: float) -> float:
+    """Return the natural log return between two prices.
+
+    The function safely handles non-positive inputs by returning ``0.0``.
+    ``price_now`` and ``price_then`` are expected to be positive floats.
+    """
+
+    if price_now <= 0 or price_then <= 0:
+        return 0.0
+    return math.log(price_now / price_then)
+
+
+def calc_currency_strength(pair_returns: Mapping[str, float]) -> Dict[str, float]:
+    """Return currency strength dictionary from pair log returns.
+
+    Each pair contributes its log return positively to the base currency
+    and negatively to the quote currency.  Contributions are averaged per
+    currency so that currencies with many pairs do not dominate the final
+    values.
 
     Parameters
     ----------
-    pair_changes : mapping
-        Keys are pair symbols like ``"EURUSD"`` and values are percentage
-        changes over some window.
+    pair_returns : mapping
+        Keys are pair symbols like ``"EURUSD"`` and values are log returns
+        over some window.
     """
-    strength: Dict[str, float] = defaultdict(float)
-    for pair, pct in pair_changes.items():
+
+    totals: Dict[str, float] = defaultdict(float)
+    counts: Dict[str, int] = defaultdict(int)
+
+    for pair, r in pair_returns.items():
         if len(pair) != 6:
             continue
         base, quote = pair[:3], pair[3:]
-        strength[base] += pct
-        strength[quote] -= pct
-    return dict(strength)
+        totals[base] += r
+        totals[quote] -= r
+        counts[base] += 1
+        counts[quote] += 1
+
+    return {ccy: totals[ccy] / counts[ccy] for ccy in totals}
 
 
 # Oscillator helpers -----------------------------------------------------------

--- a/tests/test_currency_strength.py
+++ b/tests/test_currency_strength.py
@@ -2,8 +2,8 @@ from eafix.currency_strength import calc_currency_strength
 
 
 def test_calc_currency_strength():
-    changes = {"EURUSD": 1.0, "USDJPY": -0.5}
-    strength = calc_currency_strength(changes)
+    returns = {"EURUSD": 1.0, "USDJPY": -0.5}
+    strength = calc_currency_strength(returns)
     assert strength["EUR"] == 1.0
-    assert strength["USD"] == -1.5
+    assert strength["USD"] == -0.75
     assert strength["JPY"] == 0.5

--- a/tests/test_log_return.py
+++ b/tests/test_log_return.py
@@ -1,0 +1,13 @@
+import pytest
+
+from eafix.currency_strength import log_return
+
+
+def test_log_return_basic():
+    assert log_return(110, 100) == pytest.approx(0.0953102, rel=1e-6)
+    assert log_return(100, 110) == pytest.approx(-0.0953102, rel=1e-6)
+
+
+def test_log_return_non_positive():
+    assert log_return(0, 100) == 0.0
+    assert log_return(100, 0) == 0.0


### PR DESCRIPTION
## Summary
- switch currency strength calculations to additive log returns and average per currency
- add helper for computing log return between prices
- cover currency strength weighting and log return utility with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba143a8358832f9cad6f8397f14bed