### PR TITLE
Add dynamic indicator matrix utilities with risk controls

### DIFF
--- a/src/eafix/dynamic_matrix_manager.py
+++ b/src/eafix/dynamic_matrix_manager.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+import json, os
+from dataclasses import dataclass, asdict
+from typing import Dict, Any, List, Iterable, Optional
+from .indicator_status import IndicatorStatus, format_indicator_key
+from .indicator_validator import IndicatorValidator
+
+MATRIX_STORE = os.environ.get("MATRIX_STORE", "./dynamic_matrix.json")
+
+@dataclass
+class Combo:
+    symbol: str
+    indicator_key: str
+    status: str              # EXP|VAL|TEST|PROD (canonical)
+    bias: str                # LONG|SHORT|BOTH|NONE
+    duration: str            # FLASH|QUICK|LONG|EXTENDED or NONE
+    proximity: str           # NONE for technicals; otherwise event proximity
+    context: str             # e.g., CTX:W15 to disambiguate window-based indicators
+    params: Dict[str, Any]
+
+class DynamicMatrixManager:
+    """Drop-in manager to register indicator-driven combos with explicit context tags.
+    For non-event technical indicators, set proximity to "NONE" and duration to "NONE" unless you
+    purposely bucket by duration.
+
+    Combos are stored in-memory as :class:`Combo` instances for stronger typing and are
+    serialized to dictionaries when persisted to disk or returned from public APIs.
+    """
+
+    def __init__(self, storage_path: Optional[str] = None) -> None:
+        self.storage_path = storage_path or MATRIX_STORE
+        self._combos: List[Combo] = []
+        self._load()
+
+    # ---------------- Persistence ----------------
+    def _load(self) -> None:
+        if os.path.exists(self.storage_path):
+            try:
+                with open(self.storage_path, "r", encoding="utf-8") as f:
+                    raw = json.load(f)
+                    self._combos = [Combo(**c) for c in raw]
+            except Exception:
+                self._combos = []
+        else:
+            self._combos = []
+
+    def _save(self) -> None:
+        tmp = self.storage_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump([asdict(c) for c in self._combos], f, indent=2, sort_keys=True)
+        os.replace(tmp, self.storage_path)
+
+    # ---------------- API ----------------
+    def register_indicator(
+        self,
+        *, name: str, status: IndicatorStatus, symbols: Iterable[str],
+        base_params: Dict[str, Any], windows: Iterable[int]
+    ) -> List[Dict[str, Any]]:
+        """Register indicator combos for multiple symbols and windows.
+        Adds explicit CTX:W{minutes} context and clamps risk via validator.
+        """
+        indicator_key = format_indicator_key(status, name)
+        created: List[Dict[str, Any]] = []
+        for sym in symbols:
+            for wm in windows:
+                params = dict(base_params or {})
+                params["window_minutes"] = int(wm)
+                params = IndicatorValidator.validate_param_set(params)
+
+                combo = Combo(
+                    symbol=sym,
+                    indicator_key=indicator_key,
+                    status=status.name,  # EXPERIMENTAL, VALIDATION, TEST, PRODUCTION
+                    bias=params.get("bias", "BOTH"),
+                    duration=params.get("duration", "NONE"),
+                    proximity=params.get("proximity", "NONE"),
+                    context=f"CTX:W{params['window_minutes']}",
+                    params=params,
+                )
+                IndicatorValidator.validate_combo_fields(asdict(combo))
+                self._combos.append(combo)
+                created.append(asdict(combo))
+
+        self._save()
+        return created
+
+    def list(self) -> List[Dict[str, Any]]:
+        return [asdict(c) for c in self._combos]
+
+    def find_by_indicator(self, indicator_key: str) -> List[Dict[str, Any]]:
+        indicator_key = (indicator_key or "").upper()
+        return [asdict(c) for c in self._combos if c.indicator_key.upper() == indicator_key]
+
+    def delete_by_indicator(self, indicator_key: str) -> int:
+        indicator_key = (indicator_key or "").upper()
+        before = len(self._combos)
+        self._combos = [c for c in self._combos if c.indicator_key.upper() != indicator_key]
+        removed = before - len(self._combos)
+        if removed:
+            self._save()
+        return removed

--- a/src/eafix/indicator_parameter_generator.py
+++ b/src/eafix/indicator_parameter_generator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Any, Iterable, List
+from .indicator_validator import IndicatorValidator
+
+DEFAULT_WINDOWS = [15, 60, 240, 480, 720, 1440]  # 15m, 1h, 4h, 8h, 12h, 24h
+
+@dataclass
+class PercentChangeParams:
+    window_minutes: int
+    global_risk_percent: float = 2.5
+    lookback_bars: int = 200
+    method: str = "log_return"  # or "simple_return"
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "window_minutes": self.window_minutes,
+            "global_risk_percent": self.global_risk_percent,
+            "lookback_bars": self.lookback_bars,
+            "method": self.method,
+        }
+
+def generate_percent_change_param_sets(windows: Iterable[int] = None, base_risk: float = 2.5) -> List[Dict[str, Any]]:
+    """Generate validated param sets for percent-change indicators across windows.
+    Enforces the hard risk cap (3.5%) in the validator.
+    """
+    windows = list(windows or DEFAULT_WINDOWS)
+    out: List[Dict[str, Any]] = []
+    for w in windows:
+        params = PercentChangeParams(window_minutes=int(w), global_risk_percent=float(base_risk)).as_dict()
+        out.append(IndicatorValidator.validate_param_set(params))
+    return out

--- a/src/eafix/indicator_status.py
+++ b/src/eafix/indicator_status.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum
+
+
+class IndicatorStatus(str, Enum):
+    EXPERIMENTAL = "EXP"
+    VALIDATION = "VAL"
+    TEST = "TEST"
+    PRODUCTION = "PROD"
+
+    @classmethod
+    def from_string(cls, s: str) -> "IndicatorStatus":
+        s = (s or "").strip().upper()
+        mapping = {
+            "EXP": cls.EXPERIMENTAL, "EXPERIMENTAL": cls.EXPERIMENTAL,
+            "VAL": cls.VALIDATION, "VALIDATION": cls.VALIDATION,
+            "TEST": cls.TEST, "TES": cls.TEST,
+            "PROD": cls.PRODUCTION, "PRODUCTION": cls.PRODUCTION,
+        }
+        if s not in mapping:
+            raise ValueError(f"Unknown IndicatorStatus: {s!r}")
+        return mapping[s]
+
+    @property
+    def prefix(self) -> str:
+        # Use full TEST, not TES
+        return str(self.value)
+
+def format_indicator_key(status: IndicatorStatus, name: str) -> str:
+    """Format a canonical indicator key, e.g., TEST_RSI_DIVERGENCE"""
+    if not name or not name.strip():
+        raise ValueError("Indicator name cannot be empty")
+    clean = name.strip().upper().replace(" ", "_")
+    return f"{status.prefix}_{clean}"

--- a/src/eafix/indicator_validator.py
+++ b/src/eafix/indicator_validator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+from typing import Dict, Any
+from .indicator_status import IndicatorStatus
+
+HARD_RISK_CAP = 3.5  # percent
+
+class IndicatorValidator:
+    """Validation helpers for indicator parameters and matrix combos."""
+
+    @staticmethod
+    def clamp_risk_percent(risk: float) -> float:
+        try:
+            r = float(risk)
+        except Exception as exc:
+            raise ValueError(f"risk percent must be numeric: {risk!r}") from exc
+        if r < 0:
+            r = 0.0
+        if r > HARD_RISK_CAP:
+            r = HARD_RISK_CAP
+        return round(r, 4)
+
+    @staticmethod
+    def validate_param_set(params: Dict[str, Any]) -> Dict[str, Any]:
+        """Defense-in-depth: enforce caps and sane bounds across a generated param set."""
+        out = dict(params or {})
+        # Risk
+        rp = out.get("global_risk_percent", 0)
+        out["global_risk_percent"] = IndicatorValidator.clamp_risk_percent(rp)
+
+        # Optional SL/TP/ATR constraints if present
+        if "atr_multiplier" in out:
+            am = float(out["atr_multiplier"])
+            if am <= 0:
+                raise ValueError("atr_multiplier must be > 0")
+        if "sl_pct" in out:
+            sp = float(out["sl_pct"])
+            if sp <= 0:
+                raise ValueError("sl_pct must be > 0")
+        if "tp_pct" in out:
+            tp = float(out["tp_pct"])
+            if tp <= 0:
+                raise ValueError("tp_pct must be > 0")
+        # Window minutes if present should be positive ints
+        if "window_minutes" in out:
+            wm = int(out["window_minutes"])
+            if wm <= 0:
+                raise ValueError("window_minutes must be > 0")
+            out["window_minutes"] = wm
+        return out
+
+    @staticmethod
+    def validate_combo_fields(combo: Dict[str, Any]) -> None:
+        required = ["symbol", "indicator_key", "status", "bias", "duration", "proximity", "context"]
+        for k in required:
+            if k not in combo:
+                raise ValueError(f"combo missing required field: {k}")
+        # Status must be canonical and use full TEST (not TES)
+        IndicatorStatus.from_string(combo["status"])
+        # Context must include window tag for indicator-driven signals when relevant
+        ctx = str(combo.get("context", ""))
+        if ctx and ctx.startswith("CTX:W") and not ctx[5:].isdigit():
+            raise ValueError("context window tag must look like CTX:W15 (minutes)")

--- a/tests/test_matrix_manager.py
+++ b/tests/test_matrix_manager.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+
+from eafix.indicator_status import IndicatorStatus, format_indicator_key
+from eafix.indicator_parameter_generator import generate_percent_change_param_sets
+from eafix.dynamic_matrix_manager import DynamicMatrixManager
+
+
+def test_format_key():
+    assert format_indicator_key(IndicatorStatus.TEST, "rsi divergence") == "TEST_RSI_DIVERGENCE"
+
+
+def test_generate_params_respects_cap():
+    # Intentionally set base risk above cap
+    sets = generate_percent_change_param_sets([15, 60], base_risk=9.99)
+    assert all(s["global_risk_percent"] <= 3.5 for s in sets)
+    assert sets[0]["window_minutes"] == 15 and sets[1]["window_minutes"] == 60
+
+
+def test_register_indicator_adds_context_and_clamps(tmp_path=None):
+    tmp = os.path.join(tempfile.gettempdir(), "matrix_test.json")
+    if os.path.exists(tmp):
+        os.remove(tmp)
+    mgr = DynamicMatrixManager(storage_path=tmp)
+    params = dict(global_risk_percent=9.99, bias="BOTH")
+    out = mgr.register_indicator(
+        name="percent_change",
+        status=IndicatorStatus.EXPERIMENTAL,
+        symbols=["EURUSD"],
+        base_params=params,
+        windows=[15, 60],
+    )
+    assert len(out) == 2
+    for c in out:
+        assert c["indicator_key"].startswith("EXP_")
+        assert c["context"] in {"CTX:W15", "CTX:W60"}
+        assert c["params"]["global_risk_percent"] == 3.5  # clamped


### PR DESCRIPTION
## Summary
- add `IndicatorStatus` enum and canonical key formatter
- enforce 3.5% risk cap and context tagging via validator and matrix manager
- provide parameter generator and dynamic matrix registration utilities
- store combos as dataclasses for type-safe persistence
- test risk clamping, context tags, and key formatting

## Testing
- `pytest tests/test_matrix_manager.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1b3e3dd8832f8e9e08dadebf79e7